### PR TITLE
#33 add missing cluster roles

### DIFF
--- a/charts/eck-custom-resources-operator/Chart.yaml
+++ b/charts/eck-custom-resources-operator/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
     email: marek@xco.sk
     url: https://github.com/xco-sk
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.3.0

--- a/charts/eck-custom-resources-operator/README.md
+++ b/charts/eck-custom-resources-operator/README.md
@@ -1,6 +1,6 @@
 # Helm chart for eck-custom-resources
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 Helm chart for eck-custom-resources operator
 

--- a/charts/eck-custom-resources-operator/templates/role.yaml
+++ b/charts/eck-custom-resources-operator/templates/role.yaml
@@ -354,31 +354,31 @@ rules:
   resources:
   - savedsearches/status
   verbs:
-    - get
-    - patch
-    - update
+  - get
+  - patch
+  - update
 - apiGroups:
-    - kibana.eck.github.com
+  - kibana.eck.github.com
   resources:
-    - spaces
+  - spaces
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - kibana.eck.github.com
+  - kibana.eck.github.com
   resources:
-    - spaces/finalizers
+  - spaces/finalizers
   verbs:
-    - update
+  - update
 - apiGroups:
-    - kibana.eck.github.com
+  - kibana.eck.github.com
   resources:
-    - spaces/status
+  - spaces/status
   verbs:
   - get
   - patch

--- a/charts/eck-custom-resources-operator/templates/role.yaml
+++ b/charts/eck-custom-resources-operator/templates/role.yaml
@@ -12,6 +12,39 @@ rules:
   - secrets
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - es.eck.github.com
   resources:
@@ -275,6 +308,32 @@ rules:
 - apiGroups:
   - kibana.eck.github.com
   resources:
+  - lens
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kibana.eck.github.com
+  resources:
+  - lens/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kibana.eck.github.com
+  resources:
+  - lens/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kibana.eck.github.com
+  resources:
   - savedsearches
   verbs:
   - create
@@ -294,6 +353,32 @@ rules:
   - kibana.eck.github.com
   resources:
   - savedsearches/status
+  verbs:
+    - get
+    - patch
+    - update
+- apiGroups:
+    - kibana.eck.github.com
+  resources:
+    - spaces
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - kibana.eck.github.com
+  resources:
+    - spaces/finalizers
+  verbs:
+    - update
+- apiGroups:
+    - kibana.eck.github.com
+  resources:
+    - spaces/status
   verbs:
   - get
   - patch


### PR DESCRIPTION
The cluster roles for `lens` and `space` resources were missing as well as resources required for leader election. This PR adds these resources.

Closes #33.