### PR TITLE
Build multiplatform docker image

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -43,3 +43,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -28,16 +28,16 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM --platform=$BUILDPLATFORM golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,8 +15,10 @@ COPY apis/ apis/
 COPY utils/ utils/
 COPY controllers/ controllers/
 
+ARG TARGETOS TARGETARCH
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/charts/eck-custom-resources-operator/Chart.yaml
+++ b/charts/eck-custom-resources-operator/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
     email: marek@xco.sk
     url: https://github.com/xco-sk
 type: application
-version: 0.5.4
-appVersion: 0.5.4
+version: 0.5.5
+appVersion: 0.5.5

--- a/charts/eck-custom-resources-operator/README.md
+++ b/charts/eck-custom-resources-operator/README.md
@@ -1,6 +1,6 @@
 # Helm chart for eck-custom-resources
 
-![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.4](https://img.shields.io/badge/AppVersion-0.5.4-informational?style=flat-square)
+![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.5](https://img.shields.io/badge/AppVersion-0.5.5-informational?style=flat-square)
 
 Helm chart for eck-custom-resources operator
 


### PR DESCRIPTION
build arm64 image in addition to the already setup amd64 platform

i've tested the workflow in my fork https://github.com/an-tex/eck-custom-resources/actions/runs/4937194206/jobs/8825667024 by pushing to my own docker repo https://hub.docker.com/r/antex/eck-custom-resources/tags and deploying into my arm64 cluster. the operator came up just fine :) i've tested the amd64 image on my local machine just to be sure we still build that too ;)

for more background around the Dockerfile changes https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

while a was it it i've update the github action versions in the docker-publish workflow. 